### PR TITLE
Broken Audio Link

### DIFF
--- a/js/evanindex.js
+++ b/js/evanindex.js
@@ -88,7 +88,7 @@ function teamSelection() {
     document.getElementById("demo").className = "demoMSState";
     document.getElementById("teamstats").className = "teamstatsMSState";
     imgPlacer('https://content.sportslogos.net/logos/32/755/full/mississippi_state_bulldogs_logo_primary_19957845.png');
-    fightSong('../vid/msstate.mp4.mp4');
+    fightSong('../vid/msstate.mp4');
   }
 
   if (displayTeam === 9) {

--- a/styles/evanstyle.css
+++ b/styles/evanstyle.css
@@ -1,5 +1,5 @@
 body {
-    background-color: rgb(119, 119, 119);
+    background-color: rgb(192, 176, 176);
 }
 
 .header {


### PR DESCRIPTION
MSState had 2 .mp4 in file name, fixed file name and audio file now playing correctly. Also lightened background.